### PR TITLE
Make messages have more harmony

### DIFF
--- a/draft-selander-ace-cose-ecdhe.md
+++ b/draft-selander-ace-cose-ecdhe.md
@@ -532,12 +532,12 @@ message_1 = [
 
 data_1 = (
   MSG_TYPE : int,
-  KID : bstr,
   S_U : bstr,  
   N_U : bstr,    
   E_U : serialized_COSE_Key,
   HKDFs_U : alg_array,
   AEADs_U : alg_array
+  KID : bstr,
 )
 
 aad_1 = [ data_1 ]


### PR DESCRIPTION
Making the messages be more similar makes the code easier to write fall
all versions.  Making the beginning of message #1 and message #4 be the same means that it is easier to write a single version of the code as commonality can be maintained.
