### PR TITLE
Fix wrong map length

### DIFF
--- a/EDHOC Test Vectors (Not verified!).txt
+++ b/EDHOC Test Vectors (Not verified!).txt
@@ -288,7 +288,7 @@ CRED_U =
 }
 
 CRED_U (COSE_KEY) (40 bytes)
-a4 01 01 20 06 21 58 20 42 4c 75 6a b7 7c c6 fd ec f0 b3 ec fc ff b7 53 10 c0 15 bf 5c ba 2e c0 a2 36 e6 65 0c 8a b9 c7 
+a3 01 01 20 06 21 58 20 42 4c 75 6a b7 7c c6 fd ec f0 b3 ec fc ff b7 53 10 c0 15 bf 5c ba 2e c0 a2 36 e6 65 0c 8a b9 c7 
 
 Party V's private authentication key (32 bytes)
 74 56 b3 a3 e5 8d 8d 26 dd 36 bc 75 d5 5b 88 63 a8 5d 34 72 f4 a0 1f 02 24 62 1b 1c b8 16 6d a9 
@@ -315,7 +315,7 @@ CRED_V =
 }
 
 CRED_V (COSE_KEY) (40 bytes)
-a4 01 01 20 06 21 58 20 1b 66 1e e5 d5 ef 16 72 a2 d8 77 cd 5b c2 0f 46 30 dc 78 a1 14 de 65 9c 7e 50 4d 0f 52 9a 6b d3 
+a3 01 01 20 06 21 58 20 1b 66 1e e5 d5 ef 16 72 a2 d8 77 cd 5b c2 0f 46 30 dc 78 a1 14 de 65 9c 7e 50 4d 0f 52 9a 6b d3 
 
 ---------------------------------------------------------------
 
@@ -399,7 +399,7 @@ M_V =
 ]
 
 M_V (message to be signed with Ed25519) (91 bytes)
-84 6a 53 69 67 6e 61 74 75 72 65 31 44 a1 04 41 a3 58 20 55 50 b3 dc 59 84 b0 20 9a e7 4e a2 6a 18 91 89 57 50 8e 30 33 2b 11 da 68 1d c2 af dd 87 03 55 a4 01 01 20 06 21 58 20 1b 66 1e e5 d5 ef 16 72 a2 d8 77 cd 5b c2 0f 46 30 dc 78 a1 14 de 65 9c 7e 50 4d 0f 52 9a 6b d3 
+84 6a 53 69 67 6e 61 74 75 72 65 31 44 a1 04 41 a3 58 20 55 50 b3 dc 59 84 b0 20 9a e7 4e a2 6a 18 91 89 57 50 8e 30 33 2b 11 da 68 1d c2 af dd 87 03 55 a3 01 01 20 06 21 58 20 1b 66 1e e5 d5 ef 16 72 a2 d8 77 cd 5b c2 0f 46 30 dc 78 a1 14 de 65 9c 7e 50 4d 0f 52 9a 6b d3 
 
 V's signature (64 bytes)
 f3 67 60 9c 93 08 f6 2b 1c af 73 6c e4 38 fc 4d 49 67 4c 0f 7b f3 c1 0b c2 f9 46 7e 88 58 d8 98 be a4 54 54 f1 b3 38 ab 4b 63 d6 2a ff 2d 2d 2b 2e 27 8f 42 60 24 31 9e e8 18 9a a7 b9 22 4e 0d 
@@ -487,7 +487,7 @@ M_U =
 ]
 
 M_U (message to be signed with Ed25519) (91 bytes)
-84 6a 53 69 67 6e 61 74 75 72 65 31 44 a1 04 41 a2 58 20 55 50 b3 dc 59 84 b0 20 9a e7 4e a2 6a 18 91 89 57 50 8e 30 33 2b 11 da 68 1d c2 af dd 87 03 55 a4 01 01 20 06 21 58 20 42 4c 75 6a b7 7c c6 fd ec f0 b3 ec fc ff b7 53 10 c0 15 bf 5c ba 2e c0 a2 36 e6 65 0c 8a b9 c7 
+84 6a 53 69 67 6e 61 74 75 72 65 31 44 a1 04 41 a2 58 20 55 50 b3 dc 59 84 b0 20 9a e7 4e a2 6a 18 91 89 57 50 8e 30 33 2b 11 da 68 1d c2 af dd 87 03 55 a3 01 01 20 06 21 58 20 42 4c 75 6a b7 7c c6 fd ec f0 b3 ec fc ff b7 53 10 c0 15 bf 5c ba 2e c0 a2 36 e6 65 0c 8a b9 c7 
 
 U's signature (64 bytes)
 7a 4c 50 7c 12 39 d2 d8 a6 e4 aa 74 83 f4 37 e2 f0 fe bc bb c2 56 36 8a 86 af db 7c 76 92 e1 cb ed 75 2f 07 b0 b3 5f 1f 3f 0a 60 30 d1 92 12 ef 9d 5b f2 df 97 cf 2c 1e 0b 13 62 5c ce fc cd 0b 


### PR DESCRIPTION
I started replacing the data in my unit tests with that of your test vectors. It's already helped me notice a few of my mistakes, which is great.

I also discovered something I'm pretty sure is a CBOR encoding problem in the test vectors. The `CRED_x` maps appear to have the wrong number of items. I fixed that in my changes, but beware that if you merge this, you'll have to update quite a bit of subsequent data (signatures, messages) that relies on it.

There's also something else I have a question about. Since the spec says
> TH_2 = H( bstr .cborseq [ message_1, data_2 ] )

and
> H(): the hash function in the HKDF, which takes a CBOR byte string (bstr) as
input and produces a CBOR byte string as output.

shouldn't the input to the hash function
https://github.com/EricssonResearch/EDHOC/blob/3f2ec5518b8c68db67d09f1e706c27193ffd8c37/EDHOC%20Test%20Vectors%20(Not%20verified!).txt#L383-L384
be the sequence wrapped in a CBOR bstr? Maybe I'm confused again like in the case of whether `message_i` should be wrapped in a bstr or not, but this time it very explicitly says "CBOR byte string", which I expect is not raw bytes, but wrapped in a bstr.
And because the output of the `H()` function is supposedly a CBOR byte string too, shouldn't `TH_2`
https://github.com/EricssonResearch/EDHOC/blob/3f2ec5518b8c68db67d09f1e706c27193ffd8c37/EDHOC%20Test%20Vectors%20(Not%20verified!).txt#L386-L387
also be a CBOR bstr instead of the raw 32 byte output of SHA256?
Of course that also applies to the other `TH_i` calculations. Unless the next version of the draft changes how the hashes are handled. I could imagine that, because I was wondering anyway what we gain from wrapping the sequence in a bstr *before* feeding it to the hash function. That seems like an unnecessary step.
Having `TH_i` be wrapped in a bstr *after* the calculation on the other hand, is a necessity, because it's directly put into CBOR structures like `M_x`
https://github.com/EricssonResearch/EDHOC/blob/3f2ec5518b8c68db67d09f1e706c27193ffd8c37/EDHOC%20Test%20Vectors%20(Not%20verified!).txt#L389-L399
and there it needs to be a bstr for the result to be valid CBOR. That's already done correctly in these cases.

But in the input to `TH_3`, the raw bytes of `TH_2` are used instead, which makes the resulting CBOR sequence invalid.
https://github.com/EricssonResearch/EDHOC/blob/3f2ec5518b8c68db67d09f1e706c27193ffd8c37/EDHOC%20Test%20Vectors%20(Not%20verified!).txt#L471-L472
The next element in the sequence there is `CIPHERTEXT_2`, which is also included in its raw form and causes the same problem.
Since the ciphertext is defined in the messages as being a bstr
```
message_2 = (
  data_2,
  CIPHERTEXT_2 : bstr,
)
```
I assumed it should remain as such when used as part of a sequence that is an input to the hash function. That made sense to me, since it has the benefit of letting the sequence be valid CBOR.
All of this goes for the input to `TH_4` as well.

Because this has turned into a rather large wall of text, here's the summary. It boils down to two questions:
1. Should the input sequence to the hash function be wrapped in a bstr? The draft appears to suggest so, but it doesn't seem necessary.
2. `TH_i` and `CIPHERTEXT_i` are often embedded in CBOR structures and therefore need to be wrapped in a bstr. Does that mean whenever they're used (e.g. as part of a CBOR sequence that is an input to the hash function) they are a bstr and never the raw bytes? Seems logically consistent and makes sure we never have invalid CBOR sequences.

PS: My implementation currently only does RPK authentication, so I didn't look at the ones for PSKs at all.